### PR TITLE
Remove EF Core as a dependency

### DIFF
--- a/src/NetEscapades.AspNetCore.Identity.Validators/EmailAsPasswordValidator.cs
+++ b/src/NetEscapades.AspNetCore.Identity.Validators/EmailAsPasswordValidator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
 namespace NetEscapades.AspNetCore.Identity.Validators
 {

--- a/src/NetEscapades.AspNetCore.Identity.Validators/NetEscapades.AspNetCore.Identity.Validators.csproj
+++ b/src/NetEscapades.AspNetCore.Identity.Validators/NetEscapades.AspNetCore.Identity.Validators.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NetEscapades.AspNetCore.Identity.Validators/UsernameAsPasswordValidator.cs
+++ b/src/NetEscapades.AspNetCore.Identity.Validators/UsernameAsPasswordValidator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
 namespace NetEscapades.AspNetCore.Identity.Validators
 {

--- a/test/NetEscapades.AspNetCore.Identity.Validators.Test/NetEscapades.AspNetCore.Identity.Validators.Test.csproj
+++ b/test/NetEscapades.AspNetCore.Identity.Validators.Test/NetEscapades.AspNetCore.Identity.Validators.Test.csproj
@@ -4,12 +4,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
     <PackageReference Include="Moq" Version="4.7.63" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
     <ProjectReference Include="..\..\src\NetEscapades.AspNetCore.Identity.Validators\NetEscapades.AspNetCore.Identity.Validators.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
EF Core is not required - only the base identity libraries
Means it can be more easily used with other stores, e.g. Dapper stores
